### PR TITLE
Fixed circular reference to oracledb.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -33,47 +33,49 @@ function queryStream(sql, binding, options) {
 
   stream = new Stream();
 
-  self._execute(sql, binding, options, function onExecuteDone(error, result) {
-    if (error || (!result) || (!result.resultSet)) {
+  self._execute(sql, binding, options, function onExecuteDone(err, result) {
+    if (err) {
       stream.nextRow = function emitError(streamCallback) {
-        streamCallback(error || new Error('No Results'));
+        streamCallback(err);
       };
+      
+      return;
+    }
+    
+    resultset.extend(result.resultSet);
+
+    if (stream.closed) {
+      result.resultSet.close(function onClose() {
+        stream.nextRow = function emitClose(streamCallback) {
+          streamCallback();
+        };
+      });
     } else {
-      resultset.extend(result.resultSet);
-
-      if (stream.closed) {
-        result.resultSet.close(function onClose() {
-          stream.nextRow = function emitClose(streamCallback) {
-            streamCallback();
-          };
+      var close = function (streamCallback, causeError) {
+        result.resultSet.close(function onClose(closeError) {
+          streamCallback(causeError || closeError);
         });
-      } else {
-        var close = function (streamCallback, causeError) {
-          result.resultSet.close(function onClose(closeError) {
-            streamCallback(causeError || closeError);
+      };
+
+      var readRows;
+
+      stream.nextRow = function fetchNextRow(streamCallback) {
+        if (readRows && readRows.length) {
+          streamCallback(null, readRows.shift());
+        } else {
+          result.resultSet.getRows(maxRows, function onRow(rowError, rows) {
+            if (rowError) {
+              close(streamCallback, rowError);
+            } else if ((!rows) || (!rows.length)) {
+              close(streamCallback);
+            } else {
+              readRows = rows;
+
+              streamCallback(null, readRows.shift());
+            }
           });
-        };
-
-        var readRows;
-
-        stream.nextRow = function fetchNextRow(streamCallback) {
-          if (readRows && readRows.length) {
-            streamCallback(null, readRows.shift());
-          } else {
-            result.resultSet.getRows(maxRows, function onRow(rowError, rows) {
-              if (rowError) {
-                close(streamCallback, rowError);
-              } else if ((!rows) || (!rows.length)) {
-                close(streamCallback);
-              } else {
-                readRows = rows;
-
-                streamCallback(null, readRows.shift());
-              }
-            });
-          }
-        };
-      }
+        }
+      };
     }
   });
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -20,6 +20,8 @@
 var resultset = require('./resultset.js');
 var Stream = require('./resultset-read-stream');
 
+// The queryStream function is similar to execute except that it immediately 
+// returns a readable stream.
 function queryStream(sql, binding, options) {
   var self = this;
   var stream;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,7 +19,6 @@
 
 var resultset = require('./resultset.js');
 var Stream = require('./resultset-read-stream');
-var oracledb = require('./oracledb');
 
 function queryStream(sql, binding, options) {
   var self = this;
@@ -29,8 +28,8 @@ function queryStream(sql, binding, options) {
   options = options || {};
 
   options.resultSet = true;
-
-  var maxRows = options.maxRows || oracledb.maxRows || 100;
+  
+  var maxRows = options.maxRows || self._oracledb.maxRows || 100;
 
   stream = new Stream();
 
@@ -172,12 +171,15 @@ module.break = function() {
 // The extend method is used to extend the Connection instance from the C layer with
 // custom properties and method overrides. References to the original methods are
 // maintained so they can be invoked by the overriding method at the right time.
-function extend(conn, pool) {
+function extend(conn, oracledb, pool) {
   // Using Object.defineProperties to add properties to the Connection instance with
   // special properties, such as enumerable but not writable.
   Object.defineProperties(
     conn,
     {
+      _oracledb: { // storing a reference to the base instance to avoid circular references with require
+        value: oracledb
+      },
       _pool: {
         value: pool
       },

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -67,7 +67,7 @@ function getConnection(connAttrs, createConnectionCb) {
       return;
     }
 
-    connection.extend(connInst);
+    connection.extend(connInst, self);
 
     createConnectionCb(undefined, connInst);
   });

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -48,7 +48,7 @@ function completeConnectionRequest(getConnectionCb) {
       return;
     }
 
-    connection.extend(connInst, self);
+    connection.extend(connInst, self._oracledb, self);
 
     getConnectionCb(undefined, connInst);
   });
@@ -286,12 +286,15 @@ function extend(pool, poolAttrs, oracledb) {
   Object.defineProperties(
     pool,
     {
-      queueRequests: {
-        value: queueRequests, // true will queue requests when conn pool is maxed out
+      _oracledb: { // storing a reference to the base instance to avoid circular references with require
+        value: oracledb
+      },
+      queueRequests: { // true will queue requests when conn pool is maxed out
+        value: queueRequests, 
         enumerable: true
       },
-      queueTimeout: {
-        value: queueTimeout, // milliseconds a connection request can spend in queue before being failed
+      queueTimeout: { // milliseconds a connection request can spend in queue before being failed
+        value: queueTimeout, 
         enumerable: true
       },
       _isValid: { // used to ensure operations are not done after terminate

--- a/lib/resultset-read-stream.js
+++ b/lib/resultset-read-stream.js
@@ -30,36 +30,36 @@ var Readable = stream.Readable;
  * @public
  */
 function ResultSetReadStream() {
-    var self = this;
+  var self = this;
 
-    Readable.call(self, {
-        objectMode: true
-    });
+  Readable.call(self, {
+    objectMode: true
+  });
 
-    Object.defineProperty(self, 'nextRow', {
-        /**
-         * Sets the nextRow value.
-         *
-         * @function
-         * @memberof! ResultSetReadStream
-         * @alias ResultSetReadStream.nextRow.set
-         * @private
-         * @param {function} nextRow - The next row callback function
-         */
-        set: function (nextRow) {
-            self.next = nextRow;
+  Object.defineProperty(self, 'nextRow', {
+    /**
+     * Sets the nextRow value.
+     *
+     * @function
+     * @memberof! ResultSetReadStream
+     * @alias ResultSetReadStream.nextRow.set
+     * @private
+     * @param {function} nextRow - The next row callback function
+     */
+    set: function (nextRow) {
+      self.next = nextRow;
 
-            if (self.inRead) {
-                /*jslint nomen: true */
-                /*eslint-disable no-underscore-dangle*/
-                //jscs:disable disallowDanglingUnderscores
-                self._read();
-                //jscs:enable disallowDanglingUnderscores
-                /*eslint-enable no-underscore-dangle*/
-                /*jslint nomen: false */
-            }
-        }
-    });
+      if (self.inRead) {
+        /*jslint nomen: true */
+        /*eslint-disable no-underscore-dangle*/
+        //jscs:disable disallowDanglingUnderscores
+        self._read();
+        //jscs:enable disallowDanglingUnderscores
+        /*eslint-enable no-underscore-dangle*/
+        /*jslint nomen: false */
+      }
+    }
+  });
 }
 
 util.inherits(ResultSetReadStream, Readable);
@@ -75,23 +75,23 @@ util.inherits(ResultSetReadStream, Readable);
  * @private
  */
 ResultSetReadStream.prototype._read = function () {
-    var self = this;
+  var self = this;
 
-    self.inRead = false;
+  self.inRead = false;
 
-    if (self.next) {
-        self.next(function onNextRowRead(error, data) {
-            if (error) {
-                self.emit('error', error);
-            } else if (data) {
-                self.push(data);
-            } else {
-                self.push(null);
-            }
-        });
-    } else {
-        self.inRead = true;
-    }
+  if (self.next) {
+    self.next(function onNextRowRead(error, data) {
+      if (error) {
+        self.emit('error', error);
+      } else if (data) {
+        self.push(data);
+      } else {
+        self.push(null);
+      }
+    });
+  } else {
+    self.inRead = true;
+  }
 };
 //jscs:enable disallowDanglingUnderscores
 /*eslint-enable no-underscore-dangle*/


### PR DESCRIPTION
Seemed like we had a timing issue with requiring in oracledb.js due to circular references. I've worked around the issue by adding "private" references to the base instance to pools and connections.